### PR TITLE
EP-7303

### DIFF
--- a/app/controllers/devise/twilio_two_factor_controller.rb
+++ b/app/controllers/devise/twilio_two_factor_controller.rb
@@ -89,9 +89,12 @@ class Devise::TwilioTwoFactorController < DeviseController
   def prepare_and_validate
     redirect_to :root and return if resource.nil?
 
-    if resource.login_attempts_exceeded?
-      sign_out(resource)
-      redirect_to :root
-    end
+    error_message = I18n.t('devise.twilio_two_factor.mfa_timeout') if resource.mfa_timedout?(warden.session(resource_name)["mfa_login_attempt_expires_at"])
+    error_message = I18n.t('devise.twilio_two_factor.attempt_failed') if resource.login_attempts_exceeded?
+
+    return unless error_message
+
+    sign_out(resource)
+    redirect_to "/#{resource_name.to_s.pluralize}/sign_in", alert: error_message
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,3 +6,5 @@ en:
       max_login_attempts_reached: "Access completely denied as you have reached your attempts limit"
       contact_administrator: "Please contact your system administrator."
       code_has_been_sent: "Your authentication code has been sent."
+      mfa_timeout: "You have exceeded the two-minute time limit for entering a valid MFA code. Please log in again to continue."
+

--- a/lib/devise_twilio_two_factor.rb
+++ b/lib/devise_twilio_two_factor.rb
@@ -34,6 +34,9 @@ module Devise
 
   mattr_accessor :host_name
   @@host_name = "localhost"
+
+  mattr_accessor :time_to_authenticate
+  @@time_to_authenticate = 120.seconds
 end
 
 module TwoFactorAuthentication

--- a/lib/devise_twilio_two_factor/callbacks/twilio_two_factor_authenticatable.rb
+++ b/lib/devise_twilio_two_factor/callbacks/twilio_two_factor_authenticatable.rb
@@ -7,6 +7,7 @@ Warden::Manager.after_set_user :only => [:set_user, :authentication] do |user, a
 
   if user.respond_to?(:need_two_factor_authentication?) && !bypass_by_cookie
     if auth.session(options[:scope])[TwoFactorAuthentication::NEED_AUTHENTICATION] = user.need_two_factor_authentication?
+      auth.session(options[:scope])["mfa_login_attempt_expires_at"] = Devise.time_to_authenticate.seconds.from_now.utc
       user.send_otp_code if user.send_new_otp_after_login?
       user.create_new_totp_factor if user.create_new_totp_factor_after_login?
     end

--- a/lib/devise_twilio_two_factor/models/twilio_two_factor_authenticatable.rb
+++ b/lib/devise_twilio_two_factor/models/twilio_two_factor_authenticatable.rb
@@ -27,6 +27,12 @@ module Devise
         self.failed_attempts.to_i >= Devise.maximum_attempts
       end
 
+      def mfa_timedout?(mfa_login_attempt_expires_at)
+        return false if mfa_login_attempt_expires_at.blank?
+
+        Time.now.utc > mfa_login_attempt_expires_at
+      end
+
       def need_two_factor_authentication?
         self.two_factor_auth_via_sms_enabled || self.two_factor_auth_via_authenticator_enabled
       end


### PR DESCRIPTION
- adds default module var time_to_authenticate
- locale for mfa timeout
- assigns initial timestamp mfa_login_attempt_expires_at in warden callback triggered after initial sign in and before mfa auth
- logic in twilio_two_factor_controller to logout user if they have not successfully authenticated within 2 minutes
- mfa_timedout? model method